### PR TITLE
Set initial sort state for date column of observations table

### DIFF
--- a/components/ui/table.js
+++ b/components/ui/table.js
@@ -28,6 +28,7 @@ export default function Table({ data, options, className }) {
         // Api pagination & sort
         // manual={options.manual}
         onPageChange={options.onPageChange}
+        defaultSorted={options.defaultSorted}
       />
     </div>
   );

--- a/pages/observations.js
+++ b/pages/observations.js
@@ -225,7 +225,11 @@ class ObservationsPage extends Page {
                     // pages: observations.totalSize,
                     // page: this.state.page - 1,
                     // manual: true
-                    onPageChange: page => this.onPageChange(page)
+                    onPageChange: page => this.onPageChange(page),
+                    defaultSorted: [{
+                      id: 'date',
+                      desc: false
+                    }]
                   }}
                 />
               }


### PR DESCRIPTION
Closes https://www.pivotaltracker.com/story/show/154391425

To make the filters more obvious for the table, setting an initial sort state for the first column.