### PR TITLE
Operator detail: fix localised document upload buttons layout

### DIFF
--- a/css/components/ui/_doc-card-upload.scss
+++ b/css/components/ui/_doc-card-upload.scss
@@ -16,5 +16,18 @@
         left: -9999px;
       }
     }
+
+    li:first-child {
+      margin-right: 5px;
+    }
+
+    li:nth-child(n+2) {
+      margin-left: 5px;
+    }
+
+    button {
+      white-space: normal;
+      height: 100%;
+    }
   }
 }


### PR DESCRIPTION
Fix layout for localised document upload button content:

![pasted image at 2018_01_24 06_05 pm](https://user-images.githubusercontent.com/8505382/35346092-93da1e84-0131-11e8-885e-cf561ec309e3.png)
