### PR TITLE
Update annex tooltip styling and document card

### DIFF
--- a/components/ui/doc-card.js
+++ b/components/ui/doc-card.js
@@ -143,11 +143,11 @@ class DocCard extends React.Component {
                           </dl>
                           <div className="tooltip-footer">
                             {annex.attachment &&
-                              <a href={annex.attachment.url} className="c-button -small -primary">{this.props.intl.formatMessage({ id: 'file' })}</a>
+                              <a href={annex.attachment.url} className="c-button -small -tooltip">{this.props.intl.formatMessage({ id: 'file' })}</a>
                             }
                             {isActiveUser &&
                               <button
-                                className="c-button -small -secondary"
+                                className="c-button -small -tooltip -tooltip-secondary"
                                 type="button"
                                 onClick={() => this.handleRemoveIndex(annex.id)}
                               >

--- a/components/ui/doc-card.js
+++ b/components/ui/doc-card.js
@@ -20,9 +20,21 @@ import DocNotRequiredModal from 'components/ui/doc-notrequired-modal';
 import DocAnnexesModal from 'components/ui/doc-annexes-modal';
 import Icon from 'components/ui/icon';
 import Spinner from 'components/ui/spinner';
-import { log } from 'util';
 
 class DocCard extends React.Component {
+  static propTypes = {
+    user: PropTypes.object,
+    url: PropTypes.string,
+    status: PropTypes.string,
+    title: PropTypes.string,
+    startDate: PropTypes.string,
+    endDate: PropTypes.string,
+    operatorId: PropTypes.string,
+    annexes: PropTypes.array,
+    intl: intlShape.isRequired,
+    onChange: PropTypes.func
+  };
+
   constructor(props) {
     super(props);
 
@@ -33,15 +45,6 @@ class DocCard extends React.Component {
     deleteLoading: false
   }
 
-  static propTypes = {
-    url: PropTypes.string,
-    status: PropTypes.string,
-    title: PropTypes.string,
-    startDate: PropTypes.string,
-    endDate: PropTypes.string,
-    annexes: PropTypes.array,
-    intl: intlShape.isRequired
-  };
 
   triggerWhy(e) {
     e && e.preventDefault();
@@ -94,7 +97,7 @@ class DocCard extends React.Component {
 
   render() {
     const { user, startDate, endDate, status, title, url, annexes, operatorId } = this.props;
-    const {deleteLoading} = this.state;
+    const { deleteLoading } = this.state;
     const isActiveUser = ((user && user.role === 'admin') ||
       (user && user.role === 'operator' && user.operator && user.operator.toString() === operatorId));
 
@@ -122,64 +125,65 @@ class DocCard extends React.Component {
               </a>
             </div>
             <div className="doc-card-footer">
-              <div className="doc-card-annexes-info">
-                <h3 className="c-title -default">Annexes:</h3>
-                {isActiveUser &&
-                  <button
-                    className="c-button -small -secondary"
-                    type="button"
-                    onClick={this.handleAddAnnex}
-                    >
-                    <Icon className="" name="icon-plus" />
-                  </button>
-                }
-              </div>
-              {annexes.length > 0 ?
-                <ul className="doc-card-list">
-                  {annexes.map(annex => (
-                    <li className="doc-card-list-item" key={annex.id}>
-                      <Tooltip
-                        placement="bottom"
-                        trigger={['hover']}
-                        overlay={
-                          <div>
-                            <Spinner isLoading={deleteLoading} className="-tiny -transparent" />
-                            <h4>{annex.name}</h4>
-                            <dl className="tooltip-content">
-                              <dt><strong>{this.props.intl.formatMessage({ id: 'annex.start_date' })}:</strong></dt>
-                              <dd>{annex['start-date'] ? annex['start-date'] : '-' }</dd>
-                              <dt><strong>{this.props.intl.formatMessage({ id: 'annex.expiry_date' })}:</strong></dt>
-                              <dd>{annex['expire-date'] ? annex['expire-date'] : '-'}</dd>
-                            </dl>
-                            <div className="tooltip-footer">
-                              {annex.attachment &&
-                                <a href={annex.attachment.url} className="c-button -small -primary">{this.props.intl.formatMessage({ id: 'file' })}</a>
-                              }
-                              {isActiveUser &&
-                                <button
-                                  className="c-button -small -secondary"
-                                  type="button"
-                                  onClick={() => this.handleRemoveIndex(annex.id)}
-                                  >
-                                  <Icon className="" name="icon-bin" />
-                                </button>
-                              }
-                            </div>
+              <h3 className="c-title -default doc-card-annexes-title">Annexes:</h3>
+              <ul className="doc-card-list">
+                {annexes.map(annex => (
+                  <li className="doc-card-list-item" key={annex.id}>
+                    <Tooltip
+                      placement="bottom"
+                      overlay={
+                        <div>
+                          <Spinner isLoading={deleteLoading} className="-tiny -transparent" />
+                          <h4 className="c-title -default tooltip-title">{annex.name}</h4>
+                          <dl className="tooltip-content">
+                            <dt><strong>{this.props.intl.formatMessage({ id: 'annex.start_date' })}:</strong></dt>
+                            <dd>{annex['start-date'] ? annex['start-date'] : '-' }</dd>
+                            <dt><strong>{this.props.intl.formatMessage({ id: 'annex.expiry_date' })}:</strong></dt>
+                            <dd>{annex['expire-date'] ? annex['expire-date'] : '-'}</dd>
+                          </dl>
+                          <div className="tooltip-footer">
+                            {annex.attachment &&
+                              <a href={annex.attachment.url} className="c-button -small -primary">{this.props.intl.formatMessage({ id: 'file' })}</a>
+                            }
+                            {isActiveUser &&
+                              <button
+                                className="c-button -small -secondary"
+                                type="button"
+                                onClick={() => this.handleRemoveIndex(annex.id)}
+                              >
+                                <span className="tooltip-hidden-button-text">Remove an annex</span>
+                                <Icon className="" name="icon-bin" />
+                              </button>
+                            }
                           </div>
-                        }
-                        overlayClassName="c-tooltip"
+                        </div>
+                      }
+                      overlayClassName="c-tooltip"
+                    >
+                      <button
+                        className="c-button"
+                        type="button"
                       >
-                        <button
-                          className="c-button"
-                          type="button"
-                        >
-                          <Icon className="" name="icon-file-empty" />
-                        </button>
-                      </Tooltip>
-                    </li>
-                  ))}
-                </ul> :
-                <p>No annexes</p>
+                        <Icon className="" name="icon-file-empty" />
+                      </button>
+                    </Tooltip>
+                  </li>
+                ))}
+                {isActiveUser &&
+                  <li className="doc-card-list-button" key="add-annex">
+                    <button
+                      className="c-button -small -secondary"
+                      type="button"
+                      onClick={this.handleAddAnnex}
+                    >
+                      <span className="doc-card-hidden-button-text">Add an annex</span>
+                      <Icon className="" name="icon-plus" />
+                    </button>
+                  </li>
+                }
+              </ul>
+              {!isActiveUser &&
+                <p className="doc-card-annex-text">No annexes</p>
               }
             </div>
           </div>

--- a/css/components/ui/_button.scss
+++ b/css/components/ui/_button.scss
@@ -86,6 +86,18 @@
     }
   }
 
+  &.-tooltip {
+    color: $color-white;
+    border-color: $color-white;
+    background: transparent;
+    fill: $color-white;
+
+    &.-tooltip-secondary {
+      background-color: $color-white;
+      fill: $color-primary;
+    }
+  }
+
   &.-facebook {
     display: inline-flex;
     background: #3b5998;

--- a/css/components/ui/_doc-card.scss
+++ b/css/components/ui/_doc-card.scss
@@ -42,10 +42,10 @@
   }
 
   .doc-card-list {
-    list-style: none;
-    padding: 0;
     display: flex;
     flex-wrap: wrap;
+    list-style: none;
+    padding: 0;
 
     .doc-card-list-item {
       margin-top: 10px;
@@ -54,6 +54,25 @@
     .doc-card-list-item:nth-child(n+1) {
       margin-right: 10px;
     }
+
+    .doc-card-list-button {
+      margin-top: 10px;
+
+      button {
+        padding: 5px;
+      }
+    }
+  }
+
+  .doc-card-hidden-button-text {
+    position: absolute;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
   }
 
   .doc-card-list-item {
@@ -104,19 +123,12 @@
     }
   }
 
-  .doc-card-annexes-info {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: s;
+  .doc-card-annexes-title {
+    margin: 0;
+  }
 
-    h3 {
-      margin: 0;
-    }
-
-    button {
-      padding: 5px;
-    }
+  .doc-card-annex-text {
+    font-size: $font-size-small;
   }
 
   .doc-card-date {

--- a/css/components/ui/_tooltip.scss
+++ b/css/components/ui/_tooltip.scss
@@ -16,23 +16,6 @@
     margin-left: 0;
   }
 
-  .c-button {
-    &.-primary {
-      color: white;
-      border-color: white;
-    }
-
-    &.-secondary {
-      border-color: white;
-      background: white;
-    }
-
-    .c-icon {
-      fill: $color-primary;
-    }
-  }
-
-
   .tooltip-hidden-button-text {
     position: absolute;
     overflow: hidden;

--- a/css/components/ui/_tooltip.scss
+++ b/css/components/ui/_tooltip.scss
@@ -1,7 +1,7 @@
 .c-tooltip {
   padding: 20px;
   min-width: 200px;
-  background: $color-white;
+  background-color: $color-primary;
 
   .tooltip-title {
     margin-top: 0;
@@ -15,6 +15,23 @@
   dd {
     margin-left: 0;
   }
+
+  .c-button {
+    &.-primary {
+      color: white;
+      border-color: white;
+    }
+
+    &.-secondary {
+      border-color: white;
+      background: white;
+    }
+
+    .c-icon {
+      fill: $color-primary;
+    }
+  }
+
 
   .tooltip-hidden-button-text {
     position: absolute;
@@ -33,11 +50,12 @@
 
     .rc-tooltip-inner {
       border: none;
+      color: $color-white;
+      background-color: $color-primary;
     }
 
     .rc-tooltip-arrow {
-      border-bottom-color: $color-white;
+      border-bottom-color: $color-primary;
     }
   }
 }
-

--- a/css/components/ui/_tooltip.scss
+++ b/css/components/ui/_tooltip.scss
@@ -2,9 +2,42 @@
   padding: 20px;
   min-width: 200px;
   background: $color-white;
+
+  .tooltip-title {
+    margin-top: 0;
+  }
+
+  .tooltip-footer {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  dd {
+    margin-left: 0;
+  }
+
+  .tooltip-hidden-button-text {
+    position: absolute;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+  }
+
+  // rc-tooltip overrides
+  &.rc-tooltip {
+    opacity: 1;
+
+    .rc-tooltip-inner {
+      border: none;
+    }
+
+    .rc-tooltip-arrow {
+      border-bottom-color: $color-white;
+    }
+  }
 }
 
-.tooltip-footer {
-  display: flex;
-  justify-content: space-between;
-}


### PR DESCRIPTION
**Design feedback**

**Tooltip styling:**

- [x] Arrow colour
- [x] No border
- [x] Stack tooltip items (expiry date, start date)
- [x] Remove tooltip opacity

**Document card:**
- [x] Reduce font size of "No annexes" text
- [x] Move *add annex* button to be in line with *annex icons*

![pasted image at 2018_01_25 01_05 pm](https://user-images.githubusercontent.com/8505382/35388178-03f563d0-01d3-11e8-8df8-4988046e74a3.png)

![image](https://user-images.githubusercontent.com/8505382/35388165-f52ede1c-01d2-11e8-90e2-c000429715c8.png)

**Design feedback:**

- [x] Change tooltip colour inline with map toaster/tooltip

![image](https://user-images.githubusercontent.com/8505382/35389359-b775e746-01d7-11e8-9482-ee9f0510fe80.png)

