### PR TITLE
Add VLC, VLO and TLTV certification types

### DIFF
--- a/components/operators/certificationsTd.js
+++ b/components/operators/certificationsTd.js
@@ -15,6 +15,9 @@ class CertificationsTd extends React.Component {
     const fsc = fmus.filter(f => f['certification-fsc']).length;
     const olb = fmus.filter(f => f['certification-olb']).length;
     const pefc = fmus.filter(f => f['certification-pefc']).length;
+    const vlc = fmus.filter(f => f['certification-vlc']).length;
+    const vlo = fmus.filter(f => f['certification-vlo']).length;
+    const tltv = fmus.filter(f => f['certification-tltv']).length;
 
     if (!fsc && !olb && !pefc) {
       return (
@@ -29,6 +32,9 @@ class CertificationsTd extends React.Component {
         {!!fsc && <p>FSC ({fsc})</p>}
         {!!olb && <p>OLB ({olb})</p>}
         {!!pefc && <p>PEFC ({pefc})</p>}
+        {!!vlc && <p>VLC ({vlc})</p>}
+        {!!vlo && <p>VLO ({vlo})</p>}
+        {!!tltv && <p>TLTV ({tltv})</p>}
       </div>
     );
   }

--- a/modules/operators-ranking.js
+++ b/modules/operators-ranking.js
@@ -40,7 +40,10 @@ const initialState = {
       certification: [
         { label: 'FSC', value: 'fsc' },
         { label: 'PEFC', value: 'pefc' },
-        { label: 'OLB', value: 'olb' }
+        { label: 'OLB', value: 'olb' },
+        { label: 'VLC', value: 'vlc' },
+        { label: 'VLO', value: 'vlo' },
+        { label: 'TLTV', value: 'tltv' }
       ]
     },
     loading: false,
@@ -98,7 +101,14 @@ export function getOperatorsRanking() {
     ].join(',');
 
     // Fields
-    const currentFields = { fmus: ['certification-fsc', 'certification-olb', 'certification-pefc'] };
+    const currentFields = { fmus: [
+      'certification-fsc',
+      'certification-olb',
+      'certification-pefc',
+      'certification-vlc',
+      'certification-vlo',
+      'certification-tltv'
+    ] };
     const fields = Object.keys(currentFields).map(f => `fields[${f}]=${currentFields[f]}`).join('&');
 
     // Filters

--- a/modules/user.js
+++ b/modules/user.js
@@ -68,7 +68,15 @@ export function getUserOperator(id) {
     });
 
     // Fields
-    const currentFields = { fmus: ['name', 'certification-fsc', 'certification-olb', 'certification-pefc'] };
+    const currentFields = { fmus: [
+      'name',
+      'certification-fsc',
+      'certification-olb',
+      'certification-pefc',
+      'certification-vlc',
+      'certification-vlo',
+      'certification-tltv'
+    ] };
     const fields = Object.keys(currentFields).map(f => `fields[${f}]=${currentFields[f]}`).join('&');
 
 

--- a/utils/fmu.js
+++ b/utils/fmu.js
@@ -5,12 +5,18 @@ const HELPERS_FMU = {
     const fsc = fmus.filter(f => f['certification-fsc']).length;
     const olb = fmus.filter(f => f['certification-olb']).length;
     const pefc = fmus.filter(f => f['certification-pefc']).length;
+    const vlc = fmus.filter(f => f['certification-vlc']).length;
+    const vlo = fmus.filter(f => f['certification-vlo']).length;
+    const tltv = fmus.filter(f => f['certification-tltv']).length;
 
     return (
       <div>
         {!!fsc && <p>FSC ({fsc})</p>}
         {!!olb && <p>OLB ({olb})</p>}
         {!!pefc && <p>PEFC ({pefc})</p>}
+        {!!vlc && <p>VLC ({vlc})</p>}
+        {!!vlo && <p>VLO ({vlo})</p>}
+        {!!tltv && <p>TLTV ({tltv})</p>}
       </div>
     );
   },
@@ -19,6 +25,9 @@ const HELPERS_FMU = {
     const fsc = fmu['certification-fsc'];
     const olb = fmu['certification-olb'];
     const pefc = fmu['certification-pefc'];
+    const vlo = fmu['certification-vlc'];
+    const vlc = fmu['certification-vlo'];
+    const tltv = fmu['certification-tltv'];
 
     if (!fsc && !olb && !pefc) {
       return '-';
@@ -27,7 +36,10 @@ const HELPERS_FMU = {
     const certifications = [
       !!fsc && 'FSC',
       !!olb && 'OLB',
-      !!pefc && 'PEFC'
+      !!pefc && 'PEFC',
+      !!vlc && 'VLC',
+      !!vlo && 'VLO',
+      !!tltv && 'TLTV'
     ];
 
     return (

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -38,7 +38,10 @@ const HELPERS_REGISTER = {
     return [
       { label: 'FSC', value: 'fsc' },
       { label: 'PEFC', value: 'pefc' },
-      { label: 'OLB', value: 'olb' }
+      { label: 'OLB', value: 'olb' },
+      { label: 'VLC', value: 'vlc' },
+      { label: 'VLO', value: 'vlo' },
+      { label: 'TLTV', value: 'tltv' }
     ];
   },
 
@@ -48,7 +51,10 @@ const HELPERS_REGISTER = {
       fmusGroups[id] = compact([
         !!fmusGroups[id][0]['certification-fsc'] && 'fsc',
         !!fmusGroups[id][0]['certification-pefc'] && 'pefc',
-        !!fmusGroups[id][0]['certification-olb'] && 'olb'
+        !!fmusGroups[id][0]['certification-olb'] && 'olb',
+        !!fmusGroups[id][0]['certification-vlc'] && 'vlc',
+        !!fmusGroups[id][0]['certification-vlo'] && 'vlo',
+        !!fmusGroups[id][0]['certification-tltv'] && 'tltv'
       ]);
     });
 
@@ -142,7 +148,10 @@ const HELPERS_REGISTER = {
         attributes: {
           'certification-fsc': certification.includes('fsc'),
           'certification-pefc': certification.includes('pefc'),
-          'certification-olb': certification.includes('olb')
+          'certification-olb': certification.includes('olb'),
+          'certification-vlc': certification.includes('vlc'),
+          'certification-vlo': certification.includes('vlo'),
+          'certification-tltv': certification.includes('tltv')
         }
       }
     };


### PR DESCRIPTION
@mbarrenechea could you please sense check these updates. I've add the three addition timber verification types everywhere across the app (in line with FSC, PEFC, OLB), but difficult to test.

**Closes:** 
![image](https://user-images.githubusercontent.com/8505382/35512669-dab1813a-0500-11e8-9a72-ce13710e7d02.png)

