### PR TITLE
Observations:  Add observation filters for FMU operator and report

### DIFF
--- a/constants/observations.js
+++ b/constants/observations.js
@@ -41,6 +41,21 @@ const FILTERS_REFS = [
     key: 'severity_level',
     name: 'Severity',
     placeholder: 'All Severities'
+  },
+  {
+    key: 'fmu_id',
+    name: 'Forest Management Unit',
+    placeholder: 'All FMUs'
+  },
+  {
+    key: 'observation-report',
+    name: 'Report',
+    placeholder: 'All reports'
+  },
+  {
+    key: 'operator',
+    name: 'Producer',
+    placeholder: 'All producers'
   }
 ];
 

--- a/selectors/observations/parsed-table-observations.js
+++ b/selectors/observations/parsed-table-observations.js
@@ -12,11 +12,11 @@ const getParsedTableObservations = createSelector(
         id: obs.id,
         date: new Date(obs['publication-date']).getFullYear(),
         country: obs.country.iso,
-        operator: obs.operator.name,
+        operator: !!obs.operator && obs.operator.name,
         category: obs.subcategory.category.name,
         observation: obs.details,
         level: obs.severity.level,
-        fmu: obs.fmu.name,
+        fmu: !!obs.fmu && obs.fmu.name,
         report: obs['observation-report'] ? obs['observation-report'].attachment.url : null
       }));
     }


### PR DESCRIPTION
Closes: `Add the possibility to filter by FMU and report and Forest producer` (row: 54)

![image](https://user-images.githubusercontent.com/8505382/35637157-b097ab68-06b3-11e8-9d5d-e58b3447555f.png)
