### PR TITLE
Producers: Fix localisation for docs modal

### DIFF
--- a/components/ui/doc-modal.js
+++ b/components/ui/doc-modal.js
@@ -168,7 +168,7 @@ class DocModal extends React.Component {
                     className="-fluid"
                     properties={{
                       name: 'startDate',
-                      label: this.props.intl.formatMessage({ id: 'start_date' }),
+                      label: this.props.intl.formatMessage({ id: 'doc.start_date' }),
                       type: 'date',
                       required: true,
                       default: this.state.form.startDate
@@ -185,7 +185,7 @@ class DocModal extends React.Component {
                     className="-fluid"
                     properties={{
                       name: 'expireDate',
-                      label: this.props.intl.formatMessage({ id: 'expire_date' }),
+                      label: this.props.intl.formatMessage({ id: 'doc.expiry_date' }),
                       type: 'date',
                       default: this.state.form.expireDate
                     }}


### PR DESCRIPTION
Closes: (row 8)

```
The text on the date is hte one that should only be for non requested documents. When I upload a document it says "SINCE WHEN IS THE EXPLANATION GIVEN BELOW VALID? *" and "UNTIL WHEN IS THE EXPLANATION GIVEN BELOW VALID?" instead of start date and expiry date
```