### PR TITLE
Operator Edit: Fix sawmills table layout

### DIFF
--- a/components/operators/edit.js
+++ b/components/operators/edit.js
@@ -359,10 +359,6 @@ class EditOperator extends React.Component {
               onChange={this.fetchSawmills}
             />
 
-            {!sawmills.data.length > 0 &&
-              <p>{this.props.intl.formatMessage({ id: 'edit.operators.sawmills.empty' })}</p>
-            }
-
             <button
               onClick={this.handleAddSawmill} className="c-button -small -secondary"
             >

--- a/components/ui/sawmills-table.js
+++ b/components/ui/sawmills-table.js
@@ -119,6 +119,9 @@ class SawmillsTable extends React.Component {
           ))}
           </tbody>
         </table>
+        {!sawmills.length > 0 &&
+          <p>{this.props.intl.formatMessage({ id: 'edit.operators.sawmills.empty' })}</p>
+        }
       </div>
     );
   }

--- a/css/components/ui/_options-table.scss
+++ b/css/components/ui/_options-table.scss
@@ -7,12 +7,25 @@
     width: 100%;
   }
 
-  th {
+  th:first-child {
     text-align: left;
+    width: 100%;
+  }
+
+  th {
+    min-width: 140px;
   }
 
   td {
-    min-width: 100px;
+    min-width: 140px;
+  }
+
+  td:first-child {
+    width: 100%;
+  }
+
+  td:last-child {
+    text-align: right;
   }
 
   .option-header-center {


### PR DESCRIPTION
Fixes table layout **And** position of no sawmills:

**Develop:**
![image](https://user-images.githubusercontent.com/8505382/35640115-89bfc42c-06bc-11e8-97f8-dee1dddaf9b0.png)

![image](https://user-images.githubusercontent.com/8505382/35640486-97952000-06bd-11e8-90b2-34c23ed3a84e.png)


**Fix:**
![image](https://user-images.githubusercontent.com/8505382/35640176-bf695002-06bc-11e8-8090-1a002d722804.png)

![image](https://user-images.githubusercontent.com/8505382/35640469-869fce44-06bd-11e8-9449-65a56d50a72f.png)

**Note:** Consider vertical aligning `is-active` checkboxes in the row.