### PR TITLE
Producers overview: add operator logo and company details

### DIFF
--- a/components/operators-detail/overview.js
+++ b/components/operators-detail/overview.js
@@ -1,6 +1,8 @@
 /* eslint-disable max-len */
 import React from 'react';
 import PropTypes from 'prop-types';
+import isEmpty from 'lodash/isEmpty';
+
 
 // Intl
 import { injectIntl, intlShape } from 'react-intl';
@@ -10,6 +12,8 @@ import Gallery1 from 'components/operators-detail/overview/gallery-1';
 import TotalObservationsByOperatorByCategory from 'components/operators-detail/observations/by-category';
 
 function OperatorsDetailOverview(props) {
+  const { logo, address, website } = props.operatorsDetail.data;
+
   return (
     <div
       className="c-section"
@@ -18,22 +22,50 @@ function OperatorsDetailOverview(props) {
         <Gallery1 {...props} />
 
         <article className="c-article">
-          <div className="row l-row">
-            <div className="columns small-12 medium-8">
-              <header>
-                <h2 className="c-title">
-                  {props.intl.formatMessage({ id: 'overview' })}
-                </h2>
-              </header>
-              <div className="content">
-                <div className="description">
-                  <p>
-                    {props.operatorsDetail.data.details || props.intl.formatMessage({ id: 'operator-detail.overview.details_placeholder' })}
-                  </p>
-                </div>
+          <header>
+            <h2 className="c-title">
+              {props.intl.formatMessage({ id: 'overview' })}
+            </h2>
+          </header>
+          <div className="content">
+
+            <div className="row l-row -equal-heigth">
+              <div className="columns small-12 medium-8">
+                <p className="description">
+                  {props.operatorsDetail.data.details || props.intl.formatMessage({ id: 'operator-detail.overview.details_placeholder' })}
+                </p>
+
+                { (Boolean(address) || Boolean(website)) &&
+                  <ul className="details-list">
+                    { address &&
+                      <li key="address" className="">
+                        <span>
+                          <strong>Adress:</strong>
+                          <address>{address}</address>
+                        </span>
+                      </li>
+                    }
+                    { website &&
+                      <li key="website" className="">
+                        <strong>Website:</strong>
+                        <a href={website} target="_blank" rel="noopener noreferrer">{website}</a>
+                      </li>
+                    }
+                  </ul>
+                }
               </div>
+
+              { !isEmpty(logo) &&
+                <div className="columns small-12 medium-4">
+                  <div className="c-card -primary -nolink -center-content">
+                    <img src={props.operatorsDetail.data.logo.thumbnail.url} alt={`${props.operatorsDetail.data.name} logo`} />
+                  </div>
+                </div>
+              }
+
             </div>
           </div>
+
         </article>
 
         {/* CHARTS */}

--- a/css/components/ui/_article.scss
+++ b/css/components/ui/_article.scss
@@ -20,6 +20,28 @@
     }
   }
 
+  .details-list {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+
+    li {
+      margin: 10px 0;
+    }
+
+    li:last-child {
+      margin-bottom: 0;
+    }
+
+    strong {
+      margin-right: 10px;
+    }
+
+    address {
+      display: inline-block;
+    }
+  }
+
   a {
     color: $color-primary;
     text-decoration: none;

--- a/css/components/ui/_card.scss
+++ b/css/components/ui/_card.scss
@@ -83,4 +83,11 @@
   &.-nolink {
     padding-bottom: $space-1 * 4;
   }
+
+  &.-center-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+  }
 }


### PR DESCRIPTION
**Closes:**
![image](https://user-images.githubusercontent.com/8505382/35695124-e0d0d86a-0783-11e8-8d53-9539272f6fab.png)

**Note**:

- [x] The logo is in the *Overview* section rather than the header (as per the designs)
- [x] No `address` or `website` operator data currently in the store
- [x] Placeholder text is still in place *Text presenting the Forest Producer and describing its activities* - **Should this be removed?**
- [x] There is no operator description text in the store (as per designs)

**feature/overview-details:**
![image](https://user-images.githubusercontent.com/8505382/35695335-78771774-0784-11e8-8890-c368179ce405.png)

**Design:**
![image](https://user-images.githubusercontent.com/8505382/35695367-89b4a0ba-0784-11e8-8a5a-fb0dc0385b41.png)
