### PR TITLE
Operator static header logged in user

### DIFF
--- a/components/ui/static-header.js
+++ b/components/ui/static-header.js
@@ -1,23 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
 
 class StaticHeader extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     subtitle: PropTypes.string,
     Component: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
-    background: PropTypes.string.isRequired
+    background: PropTypes.string.isRequired,
+    tabs: PropTypes.bool
   };
 
   static defaultProptypes = {
     title: '',
     subtitle: '',
     Component: null,
-    background: ''
+    background: '',
+    tabs: false
   };
 
   render() {
-    const { title, subtitle, background, Component } = this.props;
+    const { title, subtitle, background, Component, tabs } = this.props;
+    const customClassName = classnames({
+      'container -tabs': tabs
+    });
 
     return (
       <div
@@ -26,7 +33,7 @@ class StaticHeader extends React.Component {
           backgroundImage: `url(${background})`
         }}
       >
-        <div>
+        <div className={customClassName}>
           <h2>{title}</h2>
           <h3>{subtitle}</h3>
 

--- a/css/components/page/_static-header.scss
+++ b/css/components/page/_static-header.scss
@@ -29,6 +29,12 @@
     color: $color-white;
   }
 
+  .container {
+    &.-tabs {
+      margin-bottom: 45px;
+    }
+  }
+
   .static-header-component {
     margin: $space-1 * 3 0 0;
   }

--- a/pages/operators-detail.js
+++ b/pages/operators-detail.js
@@ -140,6 +140,7 @@ class OperatorsDetail extends Page {
               <a className="c-button -secondary -small">{this.props.intl.formatMessage({ id: 'update.profile' })}</a>
             </Link>
           }
+          tabs
         />
 
         <Tabs


### PR DESCRIPTION
Recent implementation of design changes to that static header had an impact on the layout of the *Update Profile* button.

**Bug:**
![image](https://user-images.githubusercontent.com/8505382/36211441-81968084-11a1-11e8-9e7e-fd871e954f33.png)


**Fix:**
![image](https://user-images.githubusercontent.com/8505382/36211315-331b4bf6-11a1-11e8-976c-3c6fb34e0b7b.png)
 