### PR TITLE
Profile: Remove broken logo file default

### DIFF
--- a/components/operators/edit.js
+++ b/components/operators/edit.js
@@ -298,8 +298,7 @@ class EditOperator extends React.Component {
               className="-fluid"
               properties={{
                 name: 'logo',
-                label: 'Logo',
-                default: this.state.form.logo
+                label: 'Logo'
               }}
             >
               {FileImage}


### PR DESCRIPTION
@mbarrenechea, removing the broken default placeholder image fixes form. Do you think this is an adequate solution?

**Closes task:**

```
On the producer profile, when we try to update information and click on save we got an error message "Error
You are not allowed to upload "html" files, allowed types: jpg, jpeg, gif, png - logo - You are not allowed to upload "html" files, allowed types: jpg, jpeg, gif, png". It only goes away when we delete the api/placerholder.png link that appear by default in the logo section.
```
