### PR TITLE
Producers: Fix title sizing

### DIFF
--- a/css/components/page/_static-header.scss
+++ b/css/components/page/_static-header.scss
@@ -18,6 +18,14 @@
     font-size: $font-size-extrahuge;
     font-weight: $font-weight-default;
     color: $color-white;
+
+    @media screen and (max-width: 1024px) {
+      font-size: $font-size-huge;
+    }
+
+    @media screen and (max-width: 780px) {
+      font-size: $font-size-large;
+    }
   }
 
   h3 {


### PR DESCRIPTION
This fix only fixes the overflow for large titles and does not implement a wider approach to responsive behaviour.

**Closes:**

```
The font size of the company's name needs to adapt to the size of the screen (check Congo Dejia Wood Industry for instance). it is not so bad with chrome but not good at all with Firefox.
```