### PR TITLE
Documentation: Update field labels for not required modal

### DIFF
--- a/components/ui/doc-modal.js
+++ b/components/ui/doc-modal.js
@@ -168,7 +168,9 @@ class DocModal extends React.Component {
                   className="-fluid"
                   properties={{
                     name: 'startDate',
-                    label: this.props.intl.formatMessage({ id: 'doc.start_date' }),
+                    label: notRequired ?
+                      this.props.intl.formatMessage({ id: 'start_date' }) :
+                      this.props.intl.formatMessage({ id: 'doc.start_date' }),
                     type: 'date',
                     required: true,
                     default: this.state.form.startDate
@@ -185,7 +187,9 @@ class DocModal extends React.Component {
                   className="-fluid"
                   properties={{
                     name: 'expireDate',
-                    label: this.props.intl.formatMessage({ id: 'doc.expiry_date' }),
+                    label: notRequired ?
+                      this.props.intl.formatMessage({ id: 'expire_date' }) :
+                      this.props.intl.formatMessage({ id: 'doc.expiry_date' }),
                     type: 'date',
                     default: this.state.form.expireDate
                   }}


### PR DESCRIPTION
**Closes:**

```
PR made - it has been fixed on the window to upload documents : we are back to the regular "start date" and "expiry date". But now the message for non requested documents is also simple "Start date" "expiry date" instead of " "Since when is the explanation given below valid?" and "Until when is the explanation given below valid?" 
```