### PR TITLE
Operators: Fix up initial map layer interactivity

### DIFF
--- a/components/form/toggle-switch.js
+++ b/components/form/toggle-switch.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+class ToggleSwitch extends React.Component {
+  state = {
+    checked: this.props.active
+  }
+
+  handleChange = (e) => {
+    const { id, handleChange } = this.props;
+    const { checked } = e.target;
+
+    handleChange(id, checked);
+
+    this.setState({ checked });
+  }
+
+  render() {
+    const { id, activeColor } = this.props;
+    const { checked } = this.state;
+
+    return (
+      <label
+        htmlFor={`toggle-${id}`}
+        className="c-toggle-switch"
+        style={{ backgroundColor: checked && activeColor }}
+      >
+        <input
+          type="checkbox"
+          id={`toggle-${id}`}
+          checked={checked}
+          onChange={this.handleChange}
+        />
+        <span className="toggle-slider" />
+      </label>
+    );
+  }
+}
+
+ToggleSwitch.propTypes = {
+  handleChange: PropTypes.func,
+  active: PropTypes.bool,
+  id: PropTypes.string,
+  activeColor: PropTypes.string
+};
+
+export default ToggleSwitch;

--- a/components/map/legend/legend-item.js
+++ b/components/map/legend/legend-item.js
@@ -3,17 +3,28 @@ import PropTypes from 'prop-types';
 
 // Components
 import LegendGraph from 'components/map/legend/legend-graph';
+import ToggleSwitch from 'components/form/toggle-switch';
 // import LegendButtons from './LegendButtons';
 // import Spinner from '../Spinner';
 
 
 class LegendItem extends React.Component {
   render() {
-    const { layer } = this.props;
+    const { layer, toggleLayers, activeLayers } = this.props;
+    const { toggle } = layer.legendConfig;
 
     return (
-      <li className="c-legend-item">
+      <li className={`c-legend-item ${toggle ? '-toggle' : ''}`}>
         <header className="legend-item-header">
+          { !!toggle &&
+            <ToggleSwitch
+              key={toggle.layerId}
+              id={toggle.layerId}
+              active={activeLayers.includes(toggle.layerId)}
+              activeColor={layer.legendConfig.color}
+              handleChange={toggleLayers}
+            />
+          }
           <h3>
             {layer.category &&
               <span className="category">{layer.category} -</span>
@@ -29,6 +40,8 @@ class LegendItem extends React.Component {
 }
 
 LegendItem.propTypes = {
+  toggleLayers: PropTypes.func,
+  activeLayers: PropTypes.array,
   layer: PropTypes.object
 };
 

--- a/components/map/map-legend.js
+++ b/components/map/map-legend.js
@@ -24,7 +24,7 @@ class MapLegend extends React.Component {
   }
 
   render() {
-    const { layers, className } = this.props;
+    const { layers, className, toggleLayers, activeLayers } = this.props;
     const { expanded } = this.state;
 
     const classNames = classnames({
@@ -58,6 +58,8 @@ class MapLegend extends React.Component {
                     )
                   }
                 }}
+                toggleLayers={toggleLayers}
+                activeLayers={activeLayers}
                 key={layer.id}
               />
             )}
@@ -75,6 +77,8 @@ MapLegend.defaultProps = {
 };
 
 MapLegend.propTypes = {
+  toggleLayers: PropTypes.func,
+  activeLayers: PropTypes.array,
   expanded: PropTypes.bool,
   layers: PropTypes.array,
   className: PropTypes.string,

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -73,9 +73,20 @@ export default class Map extends React.Component {
     }
 
     // Layers
-    if (this.layerManager && !isEqual(this.props.layers, nextProps.layers)) {
-      this.layerManager.removeAllLayers();
-      this.addLayer(nextProps.layers, { filters: nextProps.mapFilters });
+    const unionLayers = new Set([...this.props.layers, ...nextProps.layers]);
+
+    const oldLayersIds = this.props.layers.map(l => l.id);
+    const nextLayersIds = nextProps.layers.map(l => l.id);
+
+    if (this.layerManager && !isEqual(oldLayersIds, nextLayersIds)) {
+      // Test whether old & new layers are the same
+      unionLayers.forEach((layer) => {
+        if (!oldLayersIds.includes(layer.id)) {
+          this.addLayer([layer]);
+        } else if (!nextLayersIds.includes(layer.id)) {
+          layer.layers.forEach(l => this.removeLayer([l]));
+        }
+      });
     }
 
     // Filters

--- a/components/ui/sawmill-modal.js
+++ b/components/ui/sawmill-modal.js
@@ -132,7 +132,7 @@ class SawmillModal extends React.Component {
 
     return [
       {
-        id: 'sawmill',
+        id: `sawmill-${lngLat.lat}-${lngLat.lng}`,
         provider: 'geojson',
         source: {
           type: 'geojson',
@@ -153,7 +153,7 @@ class SawmillModal extends React.Component {
         },
         layers: [{
           id: 'sawmill',
-          source: 'sawmill',
+          source: `sawmill-${lngLat.lat}-${lngLat.lng}`,
           name: 'Sawmill',
           type: 'circle',
           paint: {

--- a/constants/operators.js
+++ b/constants/operators.js
@@ -20,6 +20,8 @@ const MAP_LAYERS_OPERATORS = [
       minzoom: 0,
       legendConfig: {
         type: 'basic',
+        toggle: { layerId: 'glad' },
+        color: '#FF6699',
         items: [
           { name: 'GLAD alerts (1 January 2015 - today)', color: '#FF6699' }
         ]
@@ -53,6 +55,8 @@ const MAP_LAYERS_OPERATORS = [
       minzoom: 0,
       legendConfig: {
         type: 'basic',
+        toggle: { layerId: 'loss' },
+        color: '#FF6699',
         items: [
           { name: 'Tree cover loss', color: '#FF6699' }
         ]
@@ -85,6 +89,8 @@ const MAP_LAYERS_OPERATORS = [
       minzoom: 0,
       legendConfig: {
         type: 'basic',
+        toggle: { layerId: 'gain' },
+        color: '#6D6DE5',
         items: [
           { name: 'Tree cover gain', color: '#6D6DE5' }
         ]
@@ -173,6 +179,8 @@ const MAP_LAYERS_OPERATORS = [
       minzoom: 0,
       legendConfig: {
         type: 'basic',
+        toggle: { layerId: 'protected_areas' },
+        color: '#5ca2d1',
         items: [
           { name: 'Protected areas', color: '#5ca2d1' }
         ]
@@ -221,6 +229,8 @@ const MAP_LAYERS_OPERATORS = [
       layout: {},
       legendConfig: {
         type: 'basic',
+        toggle: { layerId: 'forest_concession' },
+        color: '#e98300',
         items: [
           { name: 'FMUs', color: '#e98300' }
         ]

--- a/css/components/form/toggle-switch.scss
+++ b/css/components/form/toggle-switch.scss
@@ -1,6 +1,7 @@
 .c-toggle-switch {
   cursor: pointer;
   position: relative;
+  top: 2px;
   width: 17px;
   height: 10px;
   background: $color-gray-3;

--- a/css/components/form/toggle-switch.scss
+++ b/css/components/form/toggle-switch.scss
@@ -1,0 +1,30 @@
+.c-toggle-switch {
+  cursor: pointer;
+  position: relative;
+  width: 17px;
+  height: 10px;
+  background: $color-gray-3;
+  border-radius: 5px;
+  margin-right: 5px;
+
+  .toggle-slider {
+    position: absolute;
+    left: 2px;
+    top: 2px;
+    width: 6px;
+    height: 6px;
+    background: $color-white;
+    transform: translate(0px, 0%);
+    border-radius: 4px;
+    transition: all 0.2s cubic-bezier(0.445, 0.05, 0.55, 0.95);
+  }
+
+  input {
+    display: none;
+  }
+
+  input:checked + .toggle-slider {
+    left: calc(100% - 2px);
+    transform: translateX(-100%);
+  }
+}

--- a/css/components/map/_map-legend.scss
+++ b/css/components/map/_map-legend.scss
@@ -98,10 +98,10 @@
   &.-toggle {
     .legend-item-header {
       justify-content: flex-start;
-      align-items: center;
+      align-items: flex-start;
 
       & ~ * {
-        margin-left: $space-1 * 2;
+        margin-left: $space-1 * 3;
       }
     }
   }

--- a/css/components/map/_map-legend.scss
+++ b/css/components/map/_map-legend.scss
@@ -95,6 +95,17 @@
     border-bottom: none;
   }
 
+  &.-toggle {
+    .legend-item-header {
+      justify-content: flex-start;
+      align-items: center;
+
+      & ~ * {
+        margin-left: $space-1 * 2;
+      }
+    }
+  }
+
   .legend-item-header {
     display: flex;
     justify-content: space-between;

--- a/css/index.scss
+++ b/css/index.scss
@@ -97,3 +97,4 @@
 @import "components/form/radio";
 @import "components/form/select";
 @import "components/form/token";
+@import "components/form/toggle-switch";

--- a/modules/operators.js
+++ b/modules/operators.js
@@ -17,7 +17,7 @@ const initialState = {
   loading: false,
   error: false,
   map: {
-    activeLayers: ['loss', 'gain', 'glad']
+    activeLayers: ['loss', 'gain', 'forest_concession', 'protected_areas', 'COG', 'COD']
   }
 };
 

--- a/modules/operators.js
+++ b/modules/operators.js
@@ -7,13 +7,18 @@ const GET_OPERATORS_SUCCESS = 'GET_OPERATORS_SUCCESS';
 const GET_OPERATORS_ERROR = 'GET_OPERATORS_ERROR';
 const GET_OPERATORS_LOADING = 'GET_OPERATORS_LOADING';
 
+const SET_ACTIVE_MAP_LAYERS = 'SET_ACTIVE_MAP_LAYERS';
+
 const JSONA = new Jsona();
 
 /* Initial state */
 const initialState = {
   data: [],
   loading: false,
-  error: false
+  error: false,
+  map: {
+    activeLayers: ['loss', 'gain', 'glad']
+  }
 };
 
 /* Reducer */
@@ -25,6 +30,8 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, { error: true, loading: false });
     case GET_OPERATORS_LOADING:
       return Object.assign({}, state, { loading: true, error: false });
+    case SET_ACTIVE_MAP_LAYERS:
+      return Object.assign({}, state, { map: { activeLayers: action.payload } });
     default:
       return state;
   }
@@ -63,5 +70,12 @@ export function getOperators() {
           payload: err.message
         });
       });
+  };
+}
+
+export function setActiveMapLayers(activeLayerIds) {
+  return {
+    type: SET_ACTIVE_MAP_LAYERS,
+    payload: activeLayerIds
   };
 }

--- a/pages/operators.js
+++ b/pages/operators.js
@@ -21,7 +21,7 @@ import { HELPERS_DOC } from 'utils/documentation';
 // Redux
 import withRedux from 'next-redux-wrapper';
 import { store } from 'store';
-import { getOperators } from 'modules/operators';
+import { getOperators, setActiveMapLayers } from 'modules/operators';
 import { getOperatorsRanking, setOperatorsMapLocation, setOperatorsUrl, getOperatorsUrl } from 'modules/operators-ranking';
 import withTracker from 'components/layout/with-tracker';
 
@@ -128,6 +128,15 @@ class OperatorsPage extends Page {
     });
   }
 
+  toggleLayers = (id, checked) => {
+    const { activeLayers } = this.props.operators.map;
+
+    const toggledLayers = checked ?
+      [...activeLayers, id] : activeLayers.filter(layerId => layerId !== id);
+
+    this.props.setActiveMapLayers(toggledLayers);
+  }
+
   /**
    * HELPERS
    * - getOperatorsTable
@@ -217,6 +226,10 @@ class OperatorsPage extends Page {
 
   render() {
     const { url, operators, operatorsRanking } = this.props;
+    const { activeLayers } = operators.map;
+
+
+    const mapLayers = MAP_LAYERS_OPERATORS.filter(layer => activeLayers.includes(layer.id));
 
     // Country filters
     const countryOptions = operatorsRanking.filters.options.country.map(country => country.value);
@@ -252,13 +265,15 @@ class OperatorsPage extends Page {
                   });
                 }, 100)
               }}
-              layers={MAP_LAYERS_OPERATORS}
+              layers={mapLayers}
             />
 
             <MapLegend
               layers={flatten(MAP_LAYERS_OPERATORS.map(layer =>
                 layer.layers.filter(l => l.legendConfig)
               ))}
+              toggleLayers={this.toggleLayers}
+              activeLayers={activeLayers}
             />
 
             {/* MapControls */}
@@ -300,6 +315,9 @@ export default withTracker(withIntl(withRedux(
     setOperatorsMapLocation(mapLocation) {
       dispatch(setOperatorsMapLocation(mapLocation));
       dispatch(setOperatorsUrl());
+    },
+    setActiveMapLayers(activeLayers) {
+      dispatch(setActiveMapLayers(activeLayers));
     }
   })
 )(OperatorsPage)));

--- a/services/layerManager.js
+++ b/services/layerManager.js
@@ -50,7 +50,10 @@ export default class LayerManager {
   removeLayer(layerId) {
     if (this.map.getLayer(layerId)) {
       this.map.removeLayer(layerId);
-      this.map.removeSource(layerId);
+
+      const source = this.map.getSource(layerId);
+      if (source) this.map.removeSource(source);
+
       delete this.mapLayers[layerId];
     }
   }


### PR DESCRIPTION
*Todo:*

1. Adapt layer manager to remove `forest_concession` interactivity layers
2. Remove all layers without loading/erroring

![image](https://user-images.githubusercontent.com/8505382/39055114-aab36078-44b3-11e8-9a58-bc9fd21de059.png)
