### PR TITLE
Operator observation: Show full date without truncating

### DIFF
--- a/components/operators-detail/observations/by-category-illegality.js
+++ b/components/operators-detail/observations/by-category-illegality.js
@@ -146,7 +146,7 @@ class TotalObservationsByOperatorByCategorybyIlegallity extends React.Component 
                                         accessor: 'date',
                                         headerClassName: '-a-left',
                                         className: '-a-left',
-                                        minWidth: 75,
+                                        minWidth: 100,
                                         Cell: (attr) => {
                                           const date = new Date(attr.value);
                                           const monthName = date ? date.toLocaleString('en-us', { month: 'short' }) : '-';


### PR DESCRIPTION
Closes `Layout of the detailed view when we click on the infraction at the bottom of the page: the date is hidden`