### PR TITLE
Add additional observation table columns

### DIFF
--- a/css/components/form/checkbox.scss
+++ b/css/components/form/checkbox.scss
@@ -114,6 +114,10 @@ $checkbox-size-small: 14px;
     label {
       padding-bottom: 2px;
     }
+
+    .c-checkbox {
+      margin-top: 5px;
+    }
   }
 
   .checkbox-box-title {

--- a/css/components/ui/_table.scss
+++ b/css/components/ui/_table.scss
@@ -269,6 +269,10 @@
       &.-sev-2 { color: $lg-color-1; }
       &.-sev-3 { color: $lg-color-0; }
     }
+
+    .cell-list {
+      margin: 0;
+    }
   }
 
   // SIDEBAR THEME

--- a/modules/observations.js
+++ b/modules/observations.js
@@ -99,7 +99,7 @@ export function getObservations() {
       return null;
     }));
 
-    const includes = ['country', 'subcategory', 'subcategory.category', 'operator', 'severity', 'fmu', 'observation-report'];
+    const includes = ['country', 'subcategory', 'subcategory.category', 'operator', 'severity', 'fmu', 'observation-report', 'observers'];
 
     // Fields
     const currentFields = { fmus: ['name'], operator: ['name'] };

--- a/pages/observations.js
+++ b/pages/observations.js
@@ -124,30 +124,32 @@ class ObservationsPage extends Page {
     const { url, observations, parsedChartObservations, parsedTableObservations } = this.props;
     // Hard coded values
     const inputs = [
-      'date',
-      'country',
-      'operator',
-      'fmu',
       'category',
-      'observation',
-      'level',
-      'report',
-      'observation-type',
-      'operator-type',
-      'subcategory',
+      'country',
+      'date',
       'evidence',
+      'fmu',
+      'level',
       'litigation-status',
-      'location'
+      'location',
+      'observation',
+      'observer-organizations',
+      'observer-types',
+      'operator-type',
+      'operator',
+      'report',
+      'subcategory'
     ];
 
     const changeOfLabelLookup = {
-      operator: 'Producer',
-      fmu: 'FMU',
-      observation: 'Detail',
-      level: 'Severity',
-      'observation-type': 'Observation Type',
+      'litigation-status': 'Litigation Status',
+      'observer-organizations': 'Observer Organizations',
+      'observer-types': 'Observer Types',
       'operator-type': 'Operator Type',
-      'litigation-status': 'Litigation Status'
+      fmu: 'FMU',
+      level: 'Severity',
+      observation: 'Detail',
+      operator: 'Producer'
     };
 
     const tableOptions = inputs
@@ -191,43 +193,49 @@ class ObservationsPage extends Page {
 
 
       {
-        Header: <span className="sortable">Observation Type</span>,
-        accessor: 'observation-type',
+        Header: <span className="sortable">{this.props.intl.formatMessage({ id: 'observer-types' })}</span>,
+        accessor: 'observer-types',
         headerClassName: '-a-left',
-        className: 'observer-type',
-        minWidth: 250
-
+        className: 'observer-types',
+        minWidth: 250,
+        Cell: attr => <ul className="cell-list">{attr.value.map(type => (<li>{type}</li>))}</ul>
       },
       {
-        Header: <span className="sortable">Operator Type</span>,
+        Header: <span className="sortable">{this.props.intl.formatMessage({ id: 'observer-organizations' })}</span>,
+        accessor: 'observer-organizations',
+        headerClassName: '-a-left',
+        className: 'observer-organizations',
+        minWidth: 250,
+        Cell: attr => <ul className="cell-list">{attr.value.map(type => (<li>{type}</li>))}</ul>
+      },
+      {
+        Header: <span className="sortable">{this.props.intl.formatMessage({ id: 'operator-type' })}</span>,
         accessor: 'operator-type',
         headerClassName: '-a-left',
         className: 'operator-type',
         minWidth: 250
       },
       {
-        Header: <span className="sortable">Subcategory</span>,
+        Header: <span className="sortable">{this.props.intl.formatMessage({ id: 'subcategory' })}</span>,
         accessor: 'subcategory',
         headerClassName: '-a-left',
         className: 'subcategory',
         minWidth: 250
       },
       {
-        Header: <span className="sortable">Evidence</span>,
+        Header: <span className="sortable">{this.props.intl.formatMessage({ id: 'evidence' })}</span>,
         accessor: 'evidence',
         headerClassName: '-a-left',
         className: 'evidence',
         minWidth: 250
       },
       {
-        Header: <span className="sortable">Litigation Status</span>,
+        Header: <span className="sortable">{this.props.intl.formatMessage({ id: 'litigation-status' })}</span>,
         accessor: 'litigation-status',
         headerClassName: '-a-left',
         className: 'litigation-status',
         minWidth: 250
       },
-
-
       {
         Header: <span className="sortable">{this.props.intl.formatMessage({ id: 'detail' })}</span>,
         accessor: 'observation',

--- a/pages/observations.js
+++ b/pages/observations.js
@@ -122,14 +122,32 @@ class ObservationsPage extends Page {
 
   render() {
     const { url, observations, parsedChartObservations, parsedTableObservations } = this.props;
-
     // Hard coded values
-    const inputs = ['date', 'country', 'operator', 'fmu', 'category', 'observation', 'level', 'report', 'location'];
+    const inputs = [
+      'date',
+      'country',
+      'operator',
+      'fmu',
+      'category',
+      'observation',
+      'level',
+      'report',
+      'observation-type',
+      'operator-type',
+      'subcategory',
+      'evidence',
+      'litigation-status',
+      'location'
+    ];
+
     const changeOfLabelLookup = {
       operator: 'Producer',
       fmu: 'FMU',
       observation: 'Detail',
-      level: 'Severity'
+      level: 'Severity',
+      'observation-type': 'Observation Type',
+      'operator-type': 'Operator Type',
+      'litigation-status': 'Litigation Status'
     };
 
     const tableOptions = inputs
@@ -170,6 +188,46 @@ class ObservationsPage extends Page {
         className: 'description',
         minWidth: 120
       },
+
+
+      {
+        Header: <span className="sortable">Observation Type</span>,
+        accessor: 'observation-type',
+        headerClassName: '-a-left',
+        className: 'observer-type',
+        minWidth: 250
+
+      },
+      {
+        Header: <span className="sortable">Operator Type</span>,
+        accessor: 'operator-type',
+        headerClassName: '-a-left',
+        className: 'operator-type',
+        minWidth: 250
+      },
+      {
+        Header: <span className="sortable">Subcategory</span>,
+        accessor: 'subcategory',
+        headerClassName: '-a-left',
+        className: 'subcategory',
+        minWidth: 250
+      },
+      {
+        Header: <span className="sortable">Evidence</span>,
+        accessor: 'evidence',
+        headerClassName: '-a-left',
+        className: 'evidence',
+        minWidth: 250
+      },
+      {
+        Header: <span className="sortable">Litigation Status</span>,
+        accessor: 'litigation-status',
+        headerClassName: '-a-left',
+        className: 'litigation-status',
+        minWidth: 250
+      },
+
+
       {
         Header: <span className="sortable">{this.props.intl.formatMessage({ id: 'detail' })}</span>,
         accessor: 'observation',

--- a/selectors/observations/parsed-table-observations.js
+++ b/selectors/observations/parsed-table-observations.js
@@ -19,11 +19,12 @@ const getParsedTableObservations = createSelector(
         fmu: !!obs.fmu && obs.fmu.name,
         report: obs['observation-report'] ? obs['observation-report'].attachment.url : null,
         location: (!!obs.lat && !!obs.lng) ? { lat: Number(obs.lat), lng: Number(obs.lng) } : {},
-        'observation-type': obs['observation-type'],
         'operator-type': obs.operator.type,
         subcategory: obs.subcategory.name,
         evidence: obs.evidence,
-        'litigation-status': obs['litigation-status']
+        'litigation-status': obs['litigation-status'],
+        'observer-types': obs.observers.map(observer => observer['observer-type']),
+        'observer-organizations': obs.observers.map(observer => observer.organization)
       }));
     }
 

--- a/selectors/observations/parsed-table-observations.js
+++ b/selectors/observations/parsed-table-observations.js
@@ -18,7 +18,12 @@ const getParsedTableObservations = createSelector(
         level: obs.severity.level,
         fmu: !!obs.fmu && obs.fmu.name,
         report: obs['observation-report'] ? obs['observation-report'].attachment.url : null,
-        location: (!!obs.lat && !!obs.lng) ? { lat: Number(obs.lat), lng: Number(obs.lng) } : {}
+        location: (!!obs.lat && !!obs.lng) ? { lat: Number(obs.lat), lng: Number(obs.lng) } : {},
+        'observation-type': obs['observation-type'],
+        'operator-type': obs.operator.type,
+        subcategory: obs.subcategory.name,
+        evidence: obs.evidence,
+        'litigation-status': obs['litigation-status']
       }));
     }
 


### PR DESCRIPTION
*Task:*

```
(Observer/IM), the observer type, the operator type, the sub-categories, the evidence, illegality as written by law, Legal reference illegality, legal reference penalties, min fin max fin, penal servitude, other penalties, and the VPA indicator, that would be awesome
```

Columns added:

- [x] source (Observer/IM)
- [x] the observer type
- [x] the operator type
- [x] the sub-categories
- [x] the evidence
- [ ] illegality as written by law
- [ ] Legal reference illegality
- [ ] legal reference penalties
- [ ] min fin max fin
- [ ] penal servitude
- [ ] other penalties
- [ ] the VPA indicator

@mbarrenechea I can see any observation data for missing columns. Do you know where they could be found or if they're available?

*Note:*  Whilst not explicitly referring to the legality column requests above I have added a `'litigation-status'` column (closest match in observation data).