### PR TITLE
Add operator logo to header of operator details page

### DIFF
--- a/components/operators-detail/overview.js
+++ b/components/operators-detail/overview.js
@@ -12,7 +12,7 @@ import Gallery1 from 'components/operators-detail/overview/gallery-1';
 import TotalObservationsByOperatorByCategory from 'components/operators-detail/observations/by-category';
 
 function OperatorsDetailOverview(props) {
-  const { logo, address, website } = props.operatorsDetail.data;
+  const { address, website } = props.operatorsDetail.data;
 
   return (
     <div
@@ -54,15 +54,6 @@ function OperatorsDetailOverview(props) {
                   </ul>
                 }
               </div>
-
-              { !isEmpty(logo) &&
-                <div className="columns small-12 medium-4">
-                  <div className="c-card -primary -nolink -center-content">
-                    <img src={props.operatorsDetail.data.logo.thumbnail.url} alt={`${props.operatorsDetail.data.name} logo`} />
-                  </div>
-                </div>
-              }
-
             </div>
           </div>
 

--- a/components/ui/static-header.js
+++ b/components/ui/static-header.js
@@ -9,7 +9,8 @@ class StaticHeader extends React.Component {
     subtitle: PropTypes.string,
     Component: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     background: PropTypes.string.isRequired,
-    tabs: PropTypes.bool
+    tabs: PropTypes.bool,
+    logo: PropTypes.string
   };
 
   static defaultProptypes = {
@@ -17,32 +18,55 @@ class StaticHeader extends React.Component {
     subtitle: '',
     Component: null,
     background: '',
-    tabs: false
+    tabs: false,
+    logo: ''
   };
 
   render() {
-    const { title, subtitle, background, Component, tabs } = this.props;
-    const customClassName = classnames({
-      'container -tabs': tabs
+    const { title, subtitle, background, Component, tabs, logo } = this.props;
+    const customClasses = classnames({
+      '-tabs': tabs,
+      '-logo': !!logo
     });
 
     return (
       <div
-        className="c-static-header"
+        className={`c-static-header ${customClasses}`}
         style={{
           backgroundImage: `url(${background})`
         }}
       >
-        <div className={customClassName}>
-          <h2>{title}</h2>
-          <h3>{subtitle}</h3>
+        { tabs ?
 
-          {!!Component &&
-            <div className="static-header-component">
-              {Component}
+          <div className="wrapper">
+            <div className="container">
+              { logo &&
+                <div className="logo-container">
+                  <img
+                    src={`${process.env.NODE_ENV !== 'production' ? process.env.OTP_API : ''}${logo}`}
+                    alt={`${title} logo`}
+                    className="logo"
+                  />
+                </div>
+              }
+
+              <h2>{title}</h2>
+              <h3>{subtitle}</h3>
+
+              {!!Component &&
+                <div className="static-header-component">
+                  {Component}
+                </div>
+              }
             </div>
-          }
-        </div>
+          </div>
+        :
+          <div>
+            <h2>{title}</h2>
+            <h3>{subtitle}</h3>
+          </div>
+
+        }
       </div>
     );
   }

--- a/css/components/page/_static-header.scss
+++ b/css/components/page/_static-header.scss
@@ -12,6 +12,42 @@
 
   text-align: center;
 
+  &.-tabs {
+    .container {
+      margin-bottom: 45px;
+      text-align: left;
+      position: relative;
+    }
+
+    .wrapper {
+      max-width: 1100px;
+      padding: 0 20px;
+      margin: 0 auto;
+      width: 100%;
+    }
+  }
+
+  &.-logo {
+    height: auto;
+
+    .container {
+      position: relative;
+      margin-bottom: 75px;
+    }
+
+    .logo-container {
+      display: inline-block;
+      background-color: $color-white;
+      padding: 20px;
+    }
+
+    .logo {
+      justify-content: flex-start;
+      max-height: 50px;
+      width: auto;
+    }
+  }
+
   h2 {
     margin: 0;
     padding: 0;
@@ -37,13 +73,10 @@
     color: $color-white;
   }
 
-  .container {
-    &.-tabs {
-      margin-bottom: 45px;
-    }
-  }
-
   .static-header-component {
+    position: absolute;
+    top: 0;
+    right: 0;
     margin: $space-1 * 3 0 0;
   }
 }

--- a/pages/operators-detail.js
+++ b/pages/operators-detail.js
@@ -123,6 +123,7 @@ class OperatorsDetail extends Page {
     const { url, user, operatorsDetail, operatorObservations, operatorDocumentation } = this.props;
     const id = url.query.id;
     const tab = url.query.tab || 'overview';
+    const logoPath = operatorsDetail.data.logo ? operatorsDetail.data.logo.url : '';
 
     return (
       <Layout
@@ -147,6 +148,7 @@ class OperatorsDetail extends Page {
             </Link>
           }
           tabs
+          logo={logoPath !== '/api/placeholder.png' ? logoPath : ''}
         />
 
         <Tabs


### PR DESCRIPTION
Closes `The logo that producers upload in their profile should be displayed in the header, close to the name of the company. Contact information such as address and website should be displayed on the overview.`

![image](https://user-images.githubusercontent.com/8505382/39141158-2ea0736a-4727-11e8-9b64-8a309a15cb13.png)

![image](https://user-images.githubusercontent.com/8505382/39141172-3d10a85c-4727-11e8-8f3e-7fc0ab5be388.png)
