### PR TITLE
Producer detail: AAC layer added

### DIFF
--- a/components/map-new/layer-manager/component.js
+++ b/components/map-new/layer-manager/component.js
@@ -5,6 +5,7 @@ import { LayerManager, Layer } from 'layer-manager/dist/components';
 import { PluginMapboxGl, fetch } from 'layer-manager';
 
 import omit from 'lodash/omit';
+import slugify from 'slugify';
 
 class LayerManagerComponent extends PureComponent {
   static propTypes = {
@@ -31,6 +32,99 @@ class LayerManagerComponent extends PureComponent {
                   source: {
                     ...omit(layer.source, 'provider'),
                     data: data.attributes.geojson
+                  }
+                });
+              })
+              .catch(e => {
+                reject(e);
+              });
+          },
+          'aac-cog': (layerModel, layer, resolve, reject) => {
+            const { source } = layerModel;
+            const { provider } = source;
+
+            fetch('get', provider.url, provider.options, layerModel)
+              .then((data) => {
+                const parsedData = {
+                  ...data,
+                  features: data.features.map(f => ({
+                    ...f,
+                    properties: {
+                      ...f.properties,
+                      num_con: slugify(f.properties.num_con, {
+                        lower: true
+                      })
+                    }
+                  }))
+                };
+
+                return resolve({
+                  ...layer,
+                  source: {
+                    ...omit(layer.source, 'provider'),
+                    data: parsedData
+                  }
+                });
+              })
+              .catch(e => {
+                reject(e);
+              });
+          },
+          'aac-cod': (layerModel, layer, resolve, reject) => {
+            const { source } = layerModel;
+            const { provider } = source;
+
+            fetch('get', provider.url, provider.options, layerModel)
+              .then((data) => {
+                const parsedData = {
+                  ...data,
+                  features: data.features.map(f => ({
+                    ...f,
+                    properties: {
+                      ...f.properties,
+                      num_ccf: slugify(f.properties.num_ccf || '', {
+                        lower: true
+                      })
+                    }
+                  }))
+                };
+
+                return resolve({
+                  ...layer,
+                  source: {
+                    ...omit(layer.source, 'provider'),
+                    data: parsedData
+                  }
+                });
+              })
+              .catch(e => {
+                reject(e);
+              });
+          },
+          'aac-cmr': (layerModel, layer, resolve, reject) => {
+            const { source } = layerModel;
+            const { provider } = source;
+
+            fetch('get', provider.url, provider.options, layerModel)
+              .then((data) => {
+                const parsedData = {
+                  ...data,
+                  features: data.features.map(f => ({
+                    ...f,
+                    properties: {
+                      ...f.properties,
+                      nom_ufe: slugify(f.properties.nom_ufe || '', {
+                        lower: true
+                      })
+                    }
+                  }))
+                };
+
+                return resolve({
+                  ...layer,
+                  source: {
+                    ...omit(layer.source, 'provider'),
+                    data: parsedData
                   }
                 });
               })

--- a/constants/layers.js
+++ b/constants/layers.js
@@ -191,6 +191,156 @@ export const LAYERS = [
 
   },
   {
+    id: 'aac-cog',
+    name: 'aac',
+    iso: 'COG',
+    config: {
+      type: 'geojson',
+      source: {
+        type: 'geojson',
+        provider: {
+          type: 'aac-cog',
+          url: 'https://opendata.arcgis.com/datasets/0c31460808d84dfe806127a25fd0de62_29.geojson'
+        }
+      },
+      render: {
+        layers: [
+          {
+            type: 'fill',
+            paint: {
+              'fill-color': '#CCCCCC',
+              'fill-opacity': 0.5
+            },
+            filter: [
+              'all',
+              ['in', ['get', 'num_con'], ['literal', '{fmuNames}']]
+            ]
+          },
+          {
+            type: 'line',
+            paint: {
+              'line-color': '#CCCCCC',
+              'line-opacity': 0.5
+            },
+            filter: [
+              'all',
+              ['in', ['get', 'num_con'], ['literal', '{fmuNames}']]
+            ]
+          }
+        ]
+      }
+    },
+    paramsConfig: [
+      { key: 'fmuNames', default: [], required: true }
+    ],
+    legendConfig: {
+      type: 'basic',
+      items: [
+        { name: 'aac', color: '#CCCCCC' }
+      ]
+    }
+  },
+  {
+    id: 'aac-cod',
+    name: 'aac',
+    iso: 'COD',
+    config: {
+      type: 'geojson',
+      source: {
+        type: 'geojson',
+        provider: {
+          type: 'aac-cod',
+          url: 'https://opendata.arcgis.com/datasets/c60d5bf9e01c45c5ad79208803819db1_30.geojson'
+        }
+      },
+      render: {
+        layers: [
+          {
+            type: 'fill',
+            paint: {
+              'fill-color': '#CCCCCC',
+              'fill-opacity': 0.5
+            },
+            filter: [
+              'all',
+              ['in', ['get', 'num_ccf'], ['literal', '{fmuNames}']]
+            ]
+          },
+          {
+            type: 'line',
+            paint: {
+              'line-color': '#CCCCCC',
+              'line-opacity': 0.5
+            },
+            filter: [
+              'all',
+              ['in', ['get', 'num_ccf'], ['literal', '{fmuNames}']]
+            ]
+          }
+        ]
+      }
+    },
+    paramsConfig: [
+      { key: 'fmuNames', default: [], required: true }
+    ],
+    legendConfig: {
+      type: 'basic',
+      items: [
+        { name: 'aac', color: '#CCCCCC' }
+      ]
+    }
+  },
+  {
+    id: 'aac-cmr',
+    name: 'aac',
+    iso: 'CMR',
+    config: {
+      type: 'geojson',
+      source: {
+        type: 'geojson',
+        provider: {
+          type: 'aac-cmr',
+          url: 'https://opendata.arcgis.com/datasets/951c6b559cc945afb96013361519305b_128.geojson'
+        }
+      },
+      render: {
+        layers: [
+          {
+            type: 'fill',
+            paint: {
+              'fill-color': '#CCCCCC',
+              'fill-opacity': 0.5
+            },
+            // filter: [
+            //   'all',
+            //   ['in', ['get', 'nom_ufe'], ['literal', '{fmuNames}']]
+            // ]
+          },
+          {
+            type: 'line',
+            paint: {
+              'line-color': '#CCCCCC',
+              'line-opacity': 0.5
+            },
+            // filter: [
+            //   'all',
+            //   ['in', ['get', 'nom_ufe'], ['literal', '{fmuNames}']]
+            // ]
+          }
+        ]
+      }
+    },
+    paramsConfig: [
+      { key: 'fmuNames', default: [], required: true }
+    ],
+    legendConfig: {
+      type: 'basic',
+      items: [
+        { name: 'aac', color: '#CCCCCC' }
+      ]
+    }
+  },
+  {
     id: 'fmus',
     name: 'Forest managment units',
     config: {

--- a/css/components/map/_map.scss
+++ b/css/components/map/_map.scss
@@ -11,7 +11,7 @@
   z-index: 1;
 
   &.-static {
-    height: 700px;
+    height: 800px;
   }
 
   &.-modal {

--- a/modules/operators-detail-fmus.js
+++ b/modules/operators-detail-fmus.js
@@ -32,6 +32,9 @@ const initialState = {
     'gain',
     'loss',
     'glad',
+    'aac-cog',
+    'aac-cod',
+    'aac-cmr',
     'fmusdetail'
   ],
   layersSettings: {},

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "reselect": "^3.0.1",
     "sass-loader": "^5.0.1",
     "session-file-store": "^1.0.0",
+    "slugify": "^1.4.0",
     "turf-extent": "^1.0.4",
     "uuid": "^3.0.1",
     "viewport-mercator-project": "6.1.1",


### PR DESCRIPTION
This PR adds:
- New AAC layer in producer detail pages
  - COG and COD are filtered by name
  - CMR layer doesn't have anything that could be used as connector between fmus and aac

![image](https://user-images.githubusercontent.com/8928965/78133866-7f7e1900-741f-11ea-8b84-ea8a096fe24e.png)
