### PR TITLE
Fix/observations design rollback

### DIFF
--- a/components/observations/overview.js
+++ b/components/observations/overview.js
@@ -25,7 +25,7 @@ function Overview(props) {
 
 Overview.propTypes = {
   parsedObservations: PropTypes.array,
-  intl: intlShape.isRequired
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(Overview);

--- a/components/operators-detail/observations/by-category.js
+++ b/components/operators-detail/observations/by-category.js
@@ -80,7 +80,9 @@ export default class TotalObservationsByOperatorByCategory extends React.Compone
         <div className="row l-row">
           {Object.keys(groupedByCategory).map((category) => {
             const groupedBySeverity = HELPERS_OBS.getGroupedBySeverity(
-              groupedByCategory[category]
+              groupedByCategory[category],
+              false,
+              'severity'
             );
 
             return (

--- a/components/ui/observation-filters.js
+++ b/components/ui/observation-filters.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import isEqual from 'lodash/isEqual';
+
+import { injectIntl, intlShape } from 'react-intl';
+import Select from 'react-select';
+
+class Filters extends React.Component {
+  componentDidUpdate(prevProps) {
+    const { options, filters } = this.props;
+    const { options: prevOptions } = prevProps;
+
+    if (!isEqual(options, prevOptions)) {
+      this.props.filtersRefs.map((f) => {
+        const value = options[f.key]
+          ? options[f.key].filter((opt) =>
+              filters[f.key] ? filters[f.key].includes(opt.value) : false
+            )
+          : [];
+
+        this.setFilter(value, f.key);
+      });
+    }
+  }
+
+  setFilter(selected, key) {
+    const filter = {};
+    filter[key] = selected.map((opt) => {
+      const isVal = opt.value !== null && typeof opt.value !== 'undefined';
+      return isVal ? opt.value : opt;
+    });
+
+    this.props.setFilters(filter);
+    // this.props.logFilter(key, filter[key]);
+  }
+
+  renderFiltersSelects() {
+    const { options, filters } = this.props;
+
+    return this.props.filtersRefs.map((f) => {
+      const value = options[f.key]
+        ? options[f.key].filter((opt) =>
+            filters[f.key] ? filters[f.key].includes(opt.value) : false
+          )
+        : [];
+
+      let opts = options[f.key];
+
+      if (f.key === 'validation_status') {
+        opts = opts.map((o) => ({
+          ...o,
+          label: this.props.intl.formatMessage({
+            id: `observations.status-${o.id}`,
+          }),
+          name: this.props.intl.formatMessage({
+            id: `observations.status-${o.id}`,
+          }),
+        }));
+      }
+
+      return (
+        <div key={f.key} className="field">
+          <div className="c-select">
+            <h3 className="title">
+              {this.props.intl.formatMessage({ id: `filter.${f.key}` })}
+            </h3>
+            <Select
+              instanceId={f.key}
+              name={f.key}
+              options={opts}
+              multi
+              className={value.length ? '-filled' : ''}
+              value={value}
+              placeholder={this.props.intl.formatMessage({
+                id: `filter.${f.key}.placeholder`,
+              })}
+              onChange={(selected) => {
+                this.setFilter(selected, f.key);
+              }}
+            />
+          </div>
+        </div>
+      );
+    });
+  }
+
+  render() {
+    const { className } = this.props;
+
+    const classNames = classnames({
+      [className]: !!className,
+    });
+
+    return (
+      <aside className={`c-observation-filters ${classNames}`}>
+        <div className="filters-content">
+          <h2 className="c-title -light">
+            {this.props.intl.formatMessage({ id: 'filter.title' })}
+          </h2>
+          {this.renderFiltersSelects()}
+        </div>
+      </aside>
+    );
+  }
+}
+
+Filters.propTypes = {
+  filters: PropTypes.object,
+  filtersRefs: PropTypes.array,
+  options: PropTypes.object,
+  intl: intlShape.isRequired,
+  className: PropTypes.string,
+  // Actions
+  setFilters: PropTypes.func,
+  logFilter: PropTypes.func,
+};
+
+Filters.defaultProps = {
+  options: {},
+};
+
+export default injectIntl(Filters);

--- a/components/ui/static-header.js
+++ b/components/ui/static-header.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-
 class StaticHeader extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
@@ -10,7 +9,8 @@ class StaticHeader extends React.Component {
     Component: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     background: PropTypes.string.isRequired,
     tabs: PropTypes.bool,
-    logo: PropTypes.string
+    logo: PropTypes.string,
+    className: PropTypes.string,
   };
 
   static defaultProptypes = {
@@ -19,54 +19,64 @@ class StaticHeader extends React.Component {
     Component: null,
     background: '',
     tabs: false,
-    logo: ''
+    logo: '',
+    className: null,
   };
 
   render() {
-    const { title, subtitle, background, Component, tabs, logo } = this.props;
+    const {
+      title,
+      subtitle,
+      background,
+      Component,
+      tabs,
+      logo,
+      className,
+    } = this.props;
     const customClasses = classnames({
       '-tabs': tabs,
-      '-logo': !!logo
+      '-logo': !!logo,
+      [className]: !!className,
     });
 
     return (
       <div
         className={`c-static-header ${customClasses}`}
         style={{
-          backgroundImage: `url(${background})`
+          backgroundImage: `url(${background})`,
         }}
       >
-        { tabs ?
-
+        {tabs ? (
           <div className="wrapper">
             <div className="container">
-              { logo &&
+              {logo && (
                 <div className="logo-container">
                   <img
-                    src={`${process.env.NODE_ENV !== 'production' ? process.env.OTP_API : ''}${logo}`}
+                    src={`${
+                      process.env.NODE_ENV !== 'production'
+                        ? process.env.OTP_API
+                        : ''
+                    }${logo}`}
                     alt={`${title} logo`}
                     className="logo"
                   />
                 </div>
-              }
+              )}
 
               <h2>{title}</h2>
               <h3>{subtitle}</h3>
 
-              {!!Component &&
-                <div className="static-header-component">
-                  {Component}
-                </div>
-              }
+              {!!Component && (
+                <div className="static-header-component">{Component}</div>
+              )}
             </div>
           </div>
-        :
+        ) : (
           <div>
             <h2>{title}</h2>
             <h3>{subtitle}</h3>
           </div>
-
-        }
+        )}
       </div>
     );
   }

--- a/css/components/form/checkbox.scss
+++ b/css/components/form/checkbox.scss
@@ -126,6 +126,39 @@ $checkbox-size-small: 14px;
     }
   }
 
+  &.-secondary {
+    display: flex;
+
+    > * {
+      margin: 0 16px 0 0;
+
+      &:last-child  {
+        margin: 0;
+      }
+    }
+
+    .c-checkbox {
+      input[type='checkbox']:checked + label {
+        .checkbox-icon {
+          background-color: transparent;
+        }
+      }
+
+      .checkbox-icon {
+        border: 1px solid $color-secondary;
+
+        &:after {
+          border-left: 2px solid $color-secondary;
+          border-bottom: 2px solid $color-secondary;
+        }
+      }
+
+      .item-title {
+        margin-left: 20px;
+      }
+    }
+  }
+
   .checkbox-box-title {
     display: inline-block;
     margin-bottom: 16px;

--- a/css/components/page/_static-header.scss
+++ b/css/components/page/_static-header.scss
@@ -27,6 +27,10 @@
     }
   }
 
+  &.-short {
+    height: 250px;
+  }
+
   &.-logo {
     height: auto;
 

--- a/css/components/ui/_filters-observations.scss
+++ b/css/components/ui/_filters-observations.scss
@@ -1,0 +1,20 @@
+.c-observation-filters {
+  background-color: $color-secondary;
+  padding: 30px 30px 65px;
+
+  .c-title {
+    margin-top: 0;
+  }
+
+  .field {
+    .title {
+      font-family: $font-family-georgia;
+      color: $color-white;
+      text-transform: capitalize;
+      margin-bottom: 2px;
+      font-size: $font-size-big;
+      line-height: 26px;
+      font-weight: normal;
+    }
+  }
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -67,6 +67,7 @@
 @import 'components/ui/doc-notrequired-modal';
 @import 'components/ui/fa-attributions';
 @import 'components/ui/filters';
+@import 'components/ui/filters-observations';
 @import 'components/ui/filters-operators';
 @import 'components/ui/fmus-checkbox';
 @import 'components/ui/fmu-card';

--- a/pages/observations.js
+++ b/pages/observations.js
@@ -20,6 +20,7 @@ import { intlShape } from 'react-intl';
 
 // Selectors
 import { getParsedTableObservations } from 'selectors/observations/parsed-table-observations';
+import { getParsedChartObservations } from 'selectors/observations/parsed-chart-observations';
 import {
   getObservationsLayers,
   getObservationsLegend,
@@ -28,10 +29,11 @@ import { getParsedFilters } from 'selectors/observations/parsed-filters';
 
 // Components
 import Layout from 'components/layout/layout';
+import Overview from 'components/observations/overview';
 import CheckboxGroup from 'components/form/CheckboxGroup';
 import StaticHeader from 'components/ui/static-header';
 import Table from 'components/ui/table';
-import Filters from 'components/ui/filters';
+import Filters from 'components/ui/observation-filters';
 import Spinner from 'components/ui/spinner';
 import MapSubComponent from 'components/ui/map-sub-component';
 import StaticTabs from 'components/ui/static-tabs';
@@ -203,6 +205,7 @@ class ObservationsPage extends React.Component {
       getObservationsLegend,
       parsedFilters,
       parsedTableObservations,
+      parsedChartObservations,
     } = this.props;
 
     const changeOfLabelLookup = {
@@ -229,15 +232,28 @@ class ObservationsPage extends React.Component {
         <StaticHeader
           title={this.props.intl.formatMessage({ id: 'observations' })}
           background="/static/images/static-header/bg-observations.jpg"
+          className="-short"
         />
 
-        <Filters
-          options={parsedFilters.options}
-          filters={parsedFilters.data}
-          setFilters={this.props.setFilters}
-          filtersRefs={FILTERS_REFS}
-          // logFilter={this.logFilter}
-        />
+        <div className="c-section">
+          <div className="l-container">
+            <div className="row l-row">
+              <div className="columns small-12 medium-4">
+                <Filters
+                  options={parsedFilters.options}
+                  filters={parsedFilters.data}
+                  setFilters={this.props.setFilters}
+                  filtersRefs={FILTERS_REFS}
+                />
+              </div>
+
+              <div className="columns small-12 medium-6 medium-offset-1">
+                {/* Overview by category graphs */}
+                <Overview parsedObservations={parsedChartObservations} />
+              </div>
+            </div>
+          </div>
+        </div>
 
         <StaticTabs
           options={[
@@ -267,16 +283,18 @@ class ObservationsPage extends React.Component {
                 })}
               </h2>
               <Spinner isLoading={observations.loading} />
-              <CheckboxGroup
-                className="-inline -single-row"
-                name="observations-columns"
-                onChange={(value) => this.setActiveColumns(value)}
-                properties={{
-                  default: observations.columns,
-                  name: 'observations-columns',
-                }}
-                options={tableOptions}
-              />
+              <div className="c-field -fluid -valid">
+                <CheckboxGroup
+                  className="-single-row -small -secondary"
+                  name="observations-columns"
+                  onChange={(value) => this.setActiveColumns(value)}
+                  properties={{
+                    default: observations.columns,
+                    name: 'observations-columns',
+                  }}
+                  options={tableOptions}
+                />
+              </div>
 
               <Table
                 sortable
@@ -406,6 +424,7 @@ ObservationsPage.propTypes = {
   intl: intlShape.isRequired,
   parsedFilters: PropTypes.object,
   getObservationsLayers: PropTypes.array,
+  parsedChartObservations: PropTypes.array,
   parsedTableObservations: PropTypes.array,
 
   getObservations: PropTypes.func.isRequired,
@@ -423,6 +442,7 @@ export default withTracker(
         observations: state.observations,
         parsedFilters: getParsedFilters(state),
         parsedTableObservations: getParsedTableObservations(state),
+        parsedChartObservations: getParsedChartObservations(state),
         getObservationsLayers: getObservationsLayers(state),
         getObservationsLegend: getObservationsLegend(state, props),
       }),

--- a/selectors/observations/parsed-chart-observations.js
+++ b/selectors/observations/parsed-chart-observations.js
@@ -1,20 +1,20 @@
 import { createSelector } from 'reselect';
 
 // Get the datasets and filters from state
-const observations = state => state.observations;
+const observations = (state) => state.observations;
 
 // Create a function to compare the current active datatasets and the current datasetsIds
 const getParsedChartObservations = createSelector(
   observations,
   (_observations) => {
     if (_observations.data && _observations.data.length) {
-      return _observations.data.map(obs => ({
+      return _observations.data.map((obs) => ({
         id: obs.id,
         details: obs.details,
         severity: obs.severity && obs.severity.level,
         category: obs?.subcategory?.category?.name || '',
         illegality: obs?.subcategory?.name || '',
-        date: new Date(obs['publication-date'])
+        date: new Date(obs['publication-date']),
       }));
     }
 

--- a/utils/observations.js
+++ b/utils/observations.js
@@ -26,8 +26,9 @@ const HELPERS_OBS = {
     return groupedByFmu;
   },
 
-  getGroupedBySeverity(data, raw) {
-    const grouped = groupBy(data, 'level');
+  getGroupedBySeverity(data, raw, lookupKey) {
+    const key = lookupKey || 'level';
+    const grouped = groupBy(data, key);
     if (raw) {
       return grouped;
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7013170/106304731-04160f80-625c-11eb-92e6-3b741b1a9534.png)

Observations page restored to its original glory.

- [X] Original filters
- [X] Original checkboxes
- [X] Overview component

The overview's chart bars are still a bit shorter than the original one, I need to review that and it'll be finished.